### PR TITLE
[FEAT] 로그인 화면 구현

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
-#root {
+/* #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
-}
+  padding: 0;
+} */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
 } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Outlet } from 'react-router-dom';
+import { Header } from './components/layout/Header';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,6 +21,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={true} />
+      <Header />
       <Outlet />
     </QueryClientProvider>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+import { Button } from '../ui/Button';
+import { useEffect, useState } from 'react';
+
+export const Header = () => {
+  const [isLogin, setIsLogin] = useState(
+    !!localStorage.getItem('access_token'),
+  );
+  const handleLogout = () => {
+    // 임의로 클라이언트 측에서 로컬 스토리지에서 액세스 토큰과 쿠키 리프레시 토큰을 삭제할 것
+    window.dispatchEvent(new Event('authChange'));
+  };
+  useEffect(() => {
+    const handleAuthChange = () => {
+      setIsLogin(!!localStorage.getItem('access_token'));
+    };
+    window.addEventListener('authChange', handleAuthChange);
+
+    return () => {
+      window.removeEventListener(
+        'authChange',
+        handleAuthChange,
+      );
+    };
+  }, []);
+  return (
+    <header>
+      <nav className='flex items-center justify-between px-4 py-2 bg-gray-200 text-gray-800'>
+        <Link to='/'>
+          <span>채채봇</span>
+        </Link>
+        {isLogin && (
+          <Button variant='ghost' onClick={handleLogout}>
+            로그아웃
+          </Button>
+        )}
+        {!isLogin && (
+          <Link to='/login' className='py-1.5'>
+            로그인
+          </Link>
+        )}
+      </nav>
+    </header>
+  );
+};

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -15,6 +15,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-[#1a1a1a] text-white',
+        ghost:
+          'bg-transparent text-inherit hover:bg-neutral-300',
       },
       size: {
         default: 'h-[36px] px-[16px] py-[5px]',

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ button:focus {
 }
 
 @media (prefers-color-scheme: light) {
-  :root {
+  #root {
     color: #213547;
     background-color: #ffffff;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 
-:root {
+#root {
   font-family:
     system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -10,15 +10,16 @@
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  @apply w-full max-w-screen-2xl min-h-screen;
 }
 
 body {
   margin: 0;
   @apply flex flex-col items-center;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 input::placeholder {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom';
 import { Home } from './pages/Home.tsx';
 import { Signup } from './pages/Signup';
+import { Login } from './pages/Login';
 
 const router = createBrowserRouter([
   {
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, Component: Home },
       { path: 'signup', Component: Signup },
+      { path: 'login', Component: Login },
     ],
   },
 ]);

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -50,6 +50,7 @@ export const LoginForm = () => {
         data: request,
       });
       navigate('/');
+      window.dispatchEvent(new Event('authChange'));
     } catch (error: unknown) {
       if (error instanceof Error) {
         console.error(error.message);

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -13,6 +13,7 @@ import {
   useForm,
   type SubmitHandler,
 } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 type FormValues = {
   email: string;
@@ -28,9 +29,11 @@ export const LoginForm = () => {
   });
   const [isShowPassword, setIsShowPassword] =
     useState(false);
+  const navigate = useNavigate();
   const errorMessage =
     methods.formState.errors.root?.message ?? '';
   const EyeIcon = isShowPassword ? Eye : EyeOff;
+
   const onSubmit: SubmitHandler<FormValues> = async (
     data: FormValues,
   ) => {
@@ -46,6 +49,7 @@ export const LoginForm = () => {
         endpoint: '/users/login',
         data: request,
       });
+      navigate('/');
     } catch (error: unknown) {
       if (error instanceof Error) {
         console.error(error.message);
@@ -55,6 +59,7 @@ export const LoginForm = () => {
       }
     }
   };
+
   return (
     <FormProvider {...methods}>
       <form

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -1,0 +1,112 @@
+import { FormInput } from '@/components/FormField/FormInput';
+import { Button } from '@/components/ui/Button';
+import { fetchClient } from '@/services/fetchClient';
+import {
+  Eye,
+  EyeOff,
+  LockKeyhole,
+  Mail,
+} from 'lucide-react';
+import { useState } from 'react';
+import {
+  FormProvider,
+  useForm,
+  type SubmitHandler,
+} from 'react-hook-form';
+
+type FormValues = {
+  email: string;
+  password: string;
+};
+export const LoginForm = () => {
+  const methods = useForm<FormValues>({
+    mode: 'onChange',
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+  const [isShowPassword, setIsShowPassword] =
+    useState(false);
+  const errorMessage =
+    methods.formState.errors.root?.message ?? '';
+  const EyeIcon = isShowPassword ? Eye : EyeOff;
+  const onSubmit: SubmitHandler<FormValues> = async (
+    data: FormValues,
+  ) => {
+    const request = {
+      user: {
+        email: data.email,
+        password: data.password,
+      },
+    };
+    try {
+      await fetchClient({
+        method: 'POST',
+        endpoint: '/users/login',
+        data: request,
+      });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error(error.message);
+        methods.setError('root', {
+          message: error.message,
+        });
+      }
+    }
+  };
+  return (
+    <FormProvider {...methods}>
+      <form
+        onSubmit={methods.handleSubmit(onSubmit)}
+        className='border px-10 py-8 rounded-md'
+      >
+        <div className='flex flex-col gap-5 w-[320px]'>
+          <FormInput
+            name='email'
+            type='email'
+            placeholder='이메일'
+            classNameInput='pl-10'
+            showErrorMessage
+            rules={{ required: '이메일을 입력해주세요.' }}
+            icon={
+              <Mail className='absolute left-2 top-2' />
+            }
+          />
+          <FormInput
+            name='password'
+            type={isShowPassword ? 'text' : 'password'}
+            placeholder='비밀번호'
+            classNameInput='pl-10 pr-10'
+            showErrorMessage
+            rules={{ required: '비밀번호를 입력해주세요.' }}
+            icon={
+              <>
+                <LockKeyhole className='absolute left-2 top-1/2 -translate-y-1/2' />
+                <EyeIcon
+                  className='absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer'
+                  onClick={() =>
+                    setIsShowPassword(!isShowPassword)
+                  }
+                />
+              </>
+            }
+          />
+          {errorMessage && (
+            <p className='text-xs text-red-400'>
+              {errorMessage}
+            </p>
+          )}
+          <Button className='w-full mt-5' type='submit'>
+            로그인
+          </Button>
+        </div>
+        <div className='flex justify-center gap-2 text-xs pt-4'>
+          <p>아이디 찾기</p>
+          <p> | </p>
+          <p>비밀번호 찾기</p>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,0 +1,5 @@
+import { LoginForm } from './LoginForm';
+
+export const Login = () => {
+  return <LoginForm />;
+};

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,5 +1,9 @@
 import { LoginForm } from './LoginForm';
 
 export const Login = () => {
-  return <LoginForm />;
+  return (
+    <div className='flex items-center justify-center pt-10'>
+      <LoginForm />
+    </div>
+  );
 };

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,5 +1,9 @@
 import { SignUpForm } from './SignupForm';
 
 export const Signup = () => {
-  return <SignUpForm />;
+  return (
+    <div className='flex items-center justify-center pt-10'>
+      <SignUpForm />
+    </div>
+  );
 };

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -4,4 +4,37 @@ export const axiosInstance = axios.create({
   baseURL: 'http://localhost:8080/api',
   timeout: 3000,
   headers: { 'Content-Type': 'application/json' },
+  withCredentials: true,
 });
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('access_token');
+    if (token) {
+      config.headers.set?.(
+        'Authorization',
+        `Bearer ${token}`,
+      );
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    const newAccessToken =
+      response.headers['authorization'];
+    if (newAccessToken?.startsWith('Bearer ')) {
+      const token = newAccessToken.replace('Bearer ', '');
+      localStorage.setItem('access_token', token);
+    }
+
+    return response;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

-  #2 

## 📝 Description

- 로그인도 회원가입과 동일하게 react-hook-form으로 유효성 검사를 하며 아이디, 비밀번호 모두 입력할 수 있도록 설계했습니다. 
- API를 요청할 때, 헤더에 액세스 토큰을 자동으로 포함하도록 설계하였고, 만약 액세스 토큰이 만료되면 새로운 액세스 토큰을 포함하도록 구현했습니다. 
- 공통  Header 컴포넌트로 로그인을 하지 않으면 로그인/ 로그인을 하면 로그아웃 버튼을 보이도록 구현했습니다. 

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/4e1dc287-091a-4bef-99b9-9ce988ab6d02" />
<p>이메일, 비밀번호 모두 입력하지 않은 경우</p>
